### PR TITLE
Add rules for curly braces and square brackets

### DIFF
--- a/syntaxes/rust.tmLanguage.json
+++ b/syntaxes/rust.tmLanguage.json
@@ -158,6 +158,14 @@
                 {
                     "name": "punctuation.other.paren.rust",
                     "match": "[)(]"
+                },
+				{
+                    "name": "punctuation.other.curly.rust",
+                    "match": "[}{]"
+                },
+				{
+                    "name": "punctuation.other.squar.rust",
+                    "match": "[\\[|\\]]"
                 }
             ]
         },


### PR DESCRIPTION
"squar" typo intended. feels better when these three are the same size